### PR TITLE
Fix #16

### DIFF
--- a/SIT.Manager/Pages/PlayPage.xaml
+++ b/SIT.Manager/Pages/PlayPage.xaml
@@ -20,9 +20,9 @@
         </Popup>
 
         <StackPanel>
-            <TextBox Name="AddressBox" Margin="10" Width="300" HorizontalAlignment="Left" Text="{Binding LastServer, Mode=TwoWay}" PlaceholderText="Enter Server Address..." TextChanged="InputBox_TextChanged" Header="Address" HeaderTemplate="{StaticResource BoxHeaderTemplate}"/>
-            <TextBox Name="UsernameBox" Margin="10" Width="150" HorizontalAlignment="Left" Text="{Binding Username, Mode=TwoWay}" PlaceholderText="Enter Username..." TextChanged="InputBox_TextChanged" Header="Username" HeaderTemplate="{StaticResource BoxHeaderTemplate}"/>
-            <PasswordBox Name="PasswordBox" Margin="10" Width="150" HorizontalAlignment="Left" Password="{Binding Password, Mode=TwoWay}" PlaceholderText="Enter Password..." PasswordChanged="PasswordBox_PasswordChanged" Header="Password" HeaderTemplate="{StaticResource BoxHeaderTemplate}"/>
+            <TextBox Name="AddressBox" Margin="10" Width="300" HorizontalAlignment="Left" Text="{Binding LastServer, Mode=TwoWay}" PlaceholderText="Enter Server Address..." TextChanged="ConnectionInfo_TextChanged" Header="Address" HeaderTemplate="{StaticResource BoxHeaderTemplate}"/>
+            <TextBox Name="UsernameBox" Margin="10" Width="150" HorizontalAlignment="Left" Text="{Binding Username, Mode=TwoWay}" PlaceholderText="Enter Username..." TextChanged="ConnectionInfo_TextChanged" Header="Username" HeaderTemplate="{StaticResource BoxHeaderTemplate}"/>
+            <PasswordBox Name="PasswordBox" Margin="10" Width="150" HorizontalAlignment="Left" Password="{Binding Password, Mode=TwoWay}" PlaceholderText="Enter Password..." PasswordChanged="ConnectionInfo_TextChanged" Header="Password" HeaderTemplate="{StaticResource BoxHeaderTemplate}"/>
             <CheckBox Name="RememberMeCheck" Content="Remember Me" Margin="10" IsChecked="{Binding RememberLogin, Mode=TwoWay}"/>
             <Button Name="ConnectButton" Content="Connect" Margin="10" ToolTipService.ToolTip="Connect to the server." Click="ConnectButton_Click"/>
         </StackPanel>

--- a/SIT.Manager/Pages/PlayPage.xaml.cs
+++ b/SIT.Manager/Pages/PlayPage.xaml.cs
@@ -26,50 +26,16 @@ namespace SIT.Manager.Pages
 
             DataContext = App.ManagerConfig;
 
-            if (AddressBox.Text.Length == 0 || UsernameBox.Text.Length == 0 || PasswordBox.Password.Length == 0)
-            {
-                ConnectButton.IsEnabled = false;
-            }
+            ConnectionInfo_TextChanged(null, null);
         }
 
-        private void InputBox_TextChanged(object sender, TextChangedEventArgs e)
+        private void ConnectionInfo_TextChanged(object sender, object args)
         {
-            if (AddressBox.Text.Length == 0 || UsernameBox.Text.Length == 0 || PasswordBox.Password.Length == 0 || string.IsNullOrEmpty(App.ManagerConfig.InstallPath))
+            bool missingInfo = AddressBox.Text.Length == 0 || UsernameBox.Text.Length == 0 || PasswordBox.Password.Length == 0 || string.IsNullOrEmpty(App.ManagerConfig.InstallPath);
+            ToolTipService.SetToolTip(ConnectButton, new ToolTip()
             {
-                ToolTipService.SetToolTip(ConnectButton, new ToolTip()
-                {
-                    Content = $"Fill in all the fields first."
-                });
-                ConnectButton.IsEnabled = false;
-            }
-            else if (AddressBox.Text.Length > 0)
-            {
-                ToolTipService.SetToolTip(ConnectButton, new ToolTip()
-                {
-                    Content = $"Attempt to connect to {AddressBox.Text} and launch the game."
-                });
-                ConnectButton.IsEnabled = true;
-            }
-        }
-
-        private void PasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
-        {
-            if (AddressBox.Text.Length == 0 || UsernameBox.Text.Length == 0 || PasswordBox.Password.Length == 0 || string.IsNullOrEmpty(App.ManagerConfig.InstallPath))
-            {
-                ToolTipService.SetToolTip(ConnectButton, new ToolTip()
-                {
-                    Content = $"Fill in all the fields first."
-                });
-                ConnectButton.IsEnabled = false;
-            }
-            else if (AddressBox.Text.Length > 0)
-            {
-                ToolTipService.SetToolTip(ConnectButton, new ToolTip()
-                {
-                    Content = $"Attempt to connect to {AddressBox.Text} and launch the game."
-                });
-                ConnectButton.IsEnabled = true;
-            }
+                Content = missingInfo ? "Fill in all the fields first." : $"Attempt to connect to {AddressBox.Text} and launch the game."
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
The `Connect` method already handles missing connection info so I've removed the button disabling and changed the tooltip to a ternary. This shouldn't affect the functionality at all except for the button is now clickable without all connection info being present however a popup dialog is created by `Connect` which tells users one of the fields is missing