### PR TITLE
Add Support For Pulling Starting Profiles From the Server

### DIFF
--- a/SIT.Manager/Classes/AkiServer.cs
+++ b/SIT.Manager/Classes/AkiServer.cs
@@ -24,6 +24,8 @@ namespace SIT.Manager.Classes
             STOPPED_UNEXPECTEDLY
         }
 
+        public static string[] Editions;
+
         public static Process? Process;
 
         public static string ExeName

--- a/SIT.Manager/Controls/SelectEditionDialog.xaml.cs
+++ b/SIT.Manager/Controls/SelectEditionDialog.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml.Controls;
+using SIT.Manager.Classes;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -12,6 +13,13 @@ namespace SIT.Manager.Controls
         public SelectEditionDialog()
         {
             this.InitializeComponent();
+            EditionBox.Items.Clear();
+            for (int i = 0; i < AkiServer.Editions.Length; i++)
+            {
+                ComboBoxItem comboBoxItem = new ComboBoxItem();
+                comboBoxItem.Content = AkiServer.Editions[i];
+                EditionBox.Items.Add(comboBoxItem);
+            }
             EditionBox.SelectedIndex = 0;
         }
 

--- a/SIT.Manager/Pages/PlayPage.xaml.cs
+++ b/SIT.Manager/Pages/PlayPage.xaml.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
+using System.Linq;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -178,6 +179,9 @@ namespace SIT.Manager.Pages
                 // If failed, attempt to register
                 if (returnData == "FAILED")
                 {
+                    string jsonData = requesting.PostJson("/launcher/server/connect", JsonSerializer.Serialize(new object())).ToString();
+                    Newtonsoft.Json.Linq.JObject connectData = Newtonsoft.Json.Linq.JObject.Parse(jsonData);
+                    AkiServer.Editions = connectData["editions"].Values<string>().ToArray();
                     ContentDialog createAccountDialog = new()
                     {
                         XamlRoot = Content.XamlRoot,


### PR DESCRIPTION
Makes the launcher pull available starting profiles from the server before displaying the options during registration.