### PR TITLE
Replace address string modification with UriBuilder

### DIFF
--- a/SIT.Manager.Updater/Classes/HttpClientProgressExtensions.cs
+++ b/SIT.Manager.Updater/Classes/HttpClientProgressExtensions.cs
@@ -4,47 +4,38 @@ namespace SIT.Manager.Updater.Classes
 {
     public static class HttpClientProgressExtensions
     {
-        public static async Task DownloadDataAsync(this HttpClient client, string requestUrl, Stream destination, IProgress<float> progress = null, CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task DownloadDataAsync(this HttpClient client, string requestUrl, Stream destination, IProgress<float>? progress = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(requestUrl, HttpCompletionOption.ResponseHeadersRead))
+            using HttpResponseMessage response = await client.GetAsync(requestUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            long? contentLength = response.Content.Headers.ContentLength;
+            using var download = await response.Content.ReadAsStreamAsync(cancellationToken);
+            // no progress... no contentLength... very sad
+            if (progress is null || !contentLength.HasValue)
             {
-                var contentLength = response.Content.Headers.ContentLength;
-                using (var download = await response.Content.ReadAsStreamAsync())
-                {
-                    // no progress... no contentLength... very sad
-                    if (progress is null || !contentLength.HasValue)
-                    {
-                        await download.CopyToAsync(destination);
-                        return;
-                    }
-                    // Such progress and contentLength much reporting Wow!
-                    var progressWrapper = new Progress<long>(totalBytes => progress.Report(GetProgressPercentage(totalBytes, contentLength.Value)));
-                    await download.CopyToAsync(destination, 81920, progressWrapper, cancellationToken);
-                }
+                await download.CopyToAsync(destination, cancellationToken);
+                return;
             }
-
-            float GetProgressPercentage(float totalBytes, float currentBytes) => (totalBytes / currentBytes) * 100f;
+            // Such progress and contentLength much reporting Wow!
+            var progressWrapper = new Progress<long>(totalBytes => progress.Report((float)totalBytes / contentLength.Value));
+            await download.CopyToAsync(destination, 81920, progressWrapper, cancellationToken);
         }
 
-        static async Task CopyToAsync(this Stream source, Stream destination, int bufferSize, IProgress<long> progress = null, CancellationToken cancellationToken = default(CancellationToken))
+        static async Task CopyToAsync(this Stream source, Stream destination, int bufferSize, IProgress<long>? progress = null, CancellationToken cancellationToken = default)
         {
-            if (bufferSize < 0)
-                throw new ArgumentOutOfRangeException(nameof(bufferSize));
-            if (source is null)
-                throw new ArgumentNullException(nameof(source));
+            ArgumentOutOfRangeException.ThrowIfNegative(bufferSize);
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(destination);
             if (!source.CanRead)
                 throw new InvalidOperationException($"'{nameof(source)}' is not readable.");
-            if (destination == null)
-                throw new ArgumentNullException(nameof(destination));
             if (!destination.CanWrite)
                 throw new InvalidOperationException($"'{nameof(destination)}' is not writable.");
 
-            var buffer = new byte[bufferSize];
+            byte[] buffer = new byte[bufferSize];
             long totalBytesRead = 0;
             int bytesRead;
-            while ((bytesRead = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false)) != 0)
+            while ((bytesRead = await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) != 0)
             {
-                await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
+                await destination.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
                 totalBytesRead += bytesRead;
                 progress?.Report(totalBytesRead);
             }

--- a/SIT.Manager.Updater/Classes/ProgressBar.cs
+++ b/SIT.Manager.Updater/Classes/ProgressBar.cs
@@ -2,102 +2,103 @@
 using System.Text;
 using System.Threading;
 
-/// <summary>
-/// An ASCII progress bar
-/// </summary>
-/// Source: https://gist.github.com/DanielSWolf/0ab6a96899cc5377bf54
-public class ProgressBar : IDisposable, IProgress<double>
+namespace SIT.Manager.Updater.Classes
 {
-    private const int blockCount = 10;
-    private readonly TimeSpan animationInterval = TimeSpan.FromSeconds(1.0 / 8);
-    private const string animation = @"|/-\";
 
-    private readonly Timer timer;
-
-    private double currentProgress = 0;
-    private string currentText = string.Empty;
-    private bool disposed = false;
-    private int animationIndex = 0;
-
-    public ProgressBar()
+    /// <summary>
+    /// An ASCII progress bar
+    /// </summary>
+    /// Source: https://gist.github.com/DanielSWolf/0ab6a96899cc5377bf54
+    public class ProgressBar : IDisposable, IProgress<double>
     {
-        timer = new Timer(TimerHandler);
+        private const int blockCount = 10;
+        private readonly TimeSpan animationInterval = TimeSpan.FromSeconds(1.0 / 8);
+        private const string animation = @"|/-\";
 
-        // A progress bar is only for temporary display in a console window.
-        // If the console output is redirected to a file, draw nothing.
-        // Otherwise, we'll end up with a lot of garbage in the target file.
-        if (!Console.IsOutputRedirected)
+        private readonly Timer timer;
+
+        private double currentProgress = 0;
+        private string currentText = string.Empty;
+        private int animationIndex = 0;
+
+        public ProgressBar()
         {
-            ResetTimer();
-        }
-    }
-
-    public void Report(double value)
-    {
-        // Make sure value is in [0..1] range
-        value = Math.Max(0, Math.Min(1, value));
-        Interlocked.Exchange(ref currentProgress, value);
-    }
-
-    private void TimerHandler(object state)
-    {
-        lock (timer)
-        {
-            if (disposed) return;
-
-            int progressBlockCount = (int)(currentProgress * blockCount);
-            int percent = (int)(currentProgress * 100);
-            string text = string.Format("[{0}{1}] {2,3}% {3}",
-                new string('#', progressBlockCount), new string('-', blockCount - progressBlockCount),
-                percent,
-                animation[animationIndex++ % animation.Length]);
-            UpdateText(text);
-
-            ResetTimer();
-        }
-    }
-
-    private void UpdateText(string text)
-    {
-        // Get length of common portion
-        int commonPrefixLength = 0;
-        int commonLength = Math.Min(currentText.Length, text.Length);
-        while (commonPrefixLength < commonLength && text[commonPrefixLength] == currentText[commonPrefixLength])
-        {
-            commonPrefixLength++;
+            timer = new Timer(TimerHandler);
+            // A progress bar is only for temporary display in a console window.
+            // If the console output is redirected to a file, draw nothing.
+            // Otherwise, we'll end up with a lot of garbage in the target file.
+            if (!Console.IsOutputRedirected)
+            {
+                ResetTimer();
+            }
         }
 
-        // Backtrack to the first differing character
-        StringBuilder outputBuilder = new StringBuilder();
-        outputBuilder.Append('\b', currentText.Length - commonPrefixLength);
-
-        // Output new suffix
-        outputBuilder.Append(text.Substring(commonPrefixLength));
-
-        // If the new text is shorter than the old one: delete overlapping characters
-        int overlapCount = currentText.Length - text.Length;
-        if (overlapCount > 0)
+        public void Report(double value)
         {
-            outputBuilder.Append(' ', overlapCount);
-            outputBuilder.Append('\b', overlapCount);
+            // Make sure value is in [0..1] range
+            value = Math.Max(0, Math.Min(1, value));
+            Interlocked.Exchange(ref currentProgress, value);
         }
 
-        Console.Write(outputBuilder);
-        currentText = text;
-    }
-
-    private void ResetTimer()
-    {
-        timer.Change(animationInterval, TimeSpan.FromMilliseconds(-1));
-    }
-
-    public void Dispose()
-    {
-        lock (timer)
+        private void TimerHandler(object? state)
         {
-            disposed = true;
-            UpdateText(string.Empty);
-        }
-    }
+            lock (timer)
+            {
+                int progressBlockCount = (int)(currentProgress * blockCount);
+                int percent = (int)(currentProgress * 100);
+                string text = string.Format("[{0}{1}] {2,3}% {3}",
+                    new string('#', progressBlockCount), new string('-', blockCount - progressBlockCount),
+                    percent,
+                    animation[animationIndex++ % animation.Length]);
+                UpdateText(text);
 
+                ResetTimer();
+            }
+        }
+
+        private void UpdateText(string text)
+        {
+            // Get length of common portion
+            int commonPrefixLength = 0;
+            int commonLength = Math.Min(currentText.Length, text.Length);
+            while (commonPrefixLength < commonLength && text[commonPrefixLength] == currentText[commonPrefixLength])
+            {
+                commonPrefixLength++;
+            }
+
+            // Backtrack to the first differing character
+            StringBuilder outputBuilder = new();
+            outputBuilder.Append('\b', currentText.Length - commonPrefixLength);
+
+            // Output new suffix
+            outputBuilder.Append(text.AsSpan(commonPrefixLength));
+
+            // If the new text is shorter than the old one: delete overlapping characters
+            int overlapCount = currentText.Length - text.Length;
+            if (overlapCount > 0)
+            {
+                outputBuilder.Append(' ', overlapCount);
+                outputBuilder.Append('\b', overlapCount);
+            }
+
+            Console.Write(outputBuilder);
+            currentText = text;
+        }
+
+        private void ResetTimer()
+        {
+            timer.Change(animationInterval, TimeSpan.FromMilliseconds(-1));
+        }
+
+        public void Dispose()
+        {
+            lock (timer)
+            {
+                UpdateText(string.Empty);
+                timer.Dispose();
+            }
+            GC.SuppressFinalize(this);
+        }
+
+    }
 }

--- a/SIT.Manager.Updater/Classes/Utils.cs
+++ b/SIT.Manager.Updater/Classes/Utils.cs
@@ -12,7 +12,7 @@ namespace SIT.Manager.Updater.Classes
 
                 var newDirectory = Path.Combine(dest, Path.GetFileName(directory));
                 Directory.CreateDirectory(newDirectory);
-                MoveDirectory(directory, newDirectory);
+                await MoveDirectory(directory, newDirectory);
             }
 
             foreach (var file in Directory.GetFiles(root))

--- a/SIT.Manager/Classes/AkiServer.cs
+++ b/SIT.Manager/Classes/AkiServer.cs
@@ -24,6 +24,8 @@ namespace SIT.Manager.Classes
             STOPPED_UNEXPECTEDLY
         }
 
+        public static string[] Editions;
+
         public static Process? Process;
 
         public static string ExeName

--- a/SIT.Manager/Controls/SelectEditionDialog.xaml.cs
+++ b/SIT.Manager/Controls/SelectEditionDialog.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml.Controls;
+using SIT.Manager.Classes;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -12,6 +13,13 @@ namespace SIT.Manager.Controls
         public SelectEditionDialog()
         {
             this.InitializeComponent();
+            EditionBox.Items.Clear();
+            for (int i = 0; i < AkiServer.Editions.Length; i++)
+            {
+                ComboBoxItem comboBoxItem = new ComboBoxItem();
+                comboBoxItem.Content = AkiServer.Editions[i];
+                EditionBox.Items.Add(comboBoxItem);
+            }
             EditionBox.SelectedIndex = 0;
         }
 

--- a/SIT.Manager/Pages/PlayPage.xaml
+++ b/SIT.Manager/Pages/PlayPage.xaml
@@ -20,9 +20,9 @@
         </Popup>
 
         <StackPanel>
-            <TextBox Name="AddressBox" Margin="10" Width="300" HorizontalAlignment="Left" Text="{Binding LastServer, Mode=TwoWay}" PlaceholderText="Enter Server Address..." TextChanged="InputBox_TextChanged" Header="Address" HeaderTemplate="{StaticResource BoxHeaderTemplate}"/>
-            <TextBox Name="UsernameBox" Margin="10" Width="150" HorizontalAlignment="Left" Text="{Binding Username, Mode=TwoWay}" PlaceholderText="Enter Username..." TextChanged="InputBox_TextChanged" Header="Username" HeaderTemplate="{StaticResource BoxHeaderTemplate}"/>
-            <PasswordBox Name="PasswordBox" Margin="10" Width="150" HorizontalAlignment="Left" Password="{Binding Password, Mode=TwoWay}" PlaceholderText="Enter Password..." PasswordChanged="PasswordBox_PasswordChanged" Header="Password" HeaderTemplate="{StaticResource BoxHeaderTemplate}"/>
+            <TextBox Name="AddressBox" Margin="10" Width="300" HorizontalAlignment="Left" Text="{Binding LastServer, Mode=TwoWay}" PlaceholderText="Enter Server Address..." TextChanged="ConnectionInfo_TextChanged" Header="Address" HeaderTemplate="{StaticResource BoxHeaderTemplate}"/>
+            <TextBox Name="UsernameBox" Margin="10" Width="150" HorizontalAlignment="Left" Text="{Binding Username, Mode=TwoWay}" PlaceholderText="Enter Username..." TextChanged="ConnectionInfo_TextChanged" Header="Username" HeaderTemplate="{StaticResource BoxHeaderTemplate}"/>
+            <PasswordBox Name="PasswordBox" Margin="10" Width="150" HorizontalAlignment="Left" Password="{Binding Password, Mode=TwoWay}" PlaceholderText="Enter Password..." PasswordChanged="ConnectionInfo_TextChanged" Header="Password" HeaderTemplate="{StaticResource BoxHeaderTemplate}"/>
             <CheckBox Name="RememberMeCheck" Content="Remember Me" Margin="10" IsChecked="{Binding RememberLogin, Mode=TwoWay}"/>
             <Button Name="ConnectButton" Content="Connect" Margin="10" ToolTipService.ToolTip="Connect to the server." Click="ConnectButton_Click"/>
         </StackPanel>

--- a/SIT.Manager/Pages/PlayPage.xaml.cs
+++ b/SIT.Manager/Pages/PlayPage.xaml.cs
@@ -27,50 +27,16 @@ namespace SIT.Manager.Pages
 
             DataContext = App.ManagerConfig;
 
-            if (AddressBox.Text.Length == 0 || UsernameBox.Text.Length == 0 || PasswordBox.Password.Length == 0)
-            {
-                ConnectButton.IsEnabled = false;
-            }
+            ConnectionInfo_TextChanged(null, null);
         }
 
-        private void InputBox_TextChanged(object sender, TextChangedEventArgs e)
+        private void ConnectionInfo_TextChanged(object sender, object args)
         {
-            if (AddressBox.Text.Length == 0 || UsernameBox.Text.Length == 0 || PasswordBox.Password.Length == 0 || string.IsNullOrEmpty(App.ManagerConfig.InstallPath))
+            bool missingInfo = AddressBox.Text.Length == 0 || UsernameBox.Text.Length == 0 || PasswordBox.Password.Length == 0 || string.IsNullOrEmpty(App.ManagerConfig.InstallPath);
+            ToolTipService.SetToolTip(ConnectButton, new ToolTip()
             {
-                ToolTipService.SetToolTip(ConnectButton, new ToolTip()
-                {
-                    Content = $"Fill in all the fields first."
-                });
-                ConnectButton.IsEnabled = false;
-            }
-            else if (AddressBox.Text.Length > 0)
-            {
-                ToolTipService.SetToolTip(ConnectButton, new ToolTip()
-                {
-                    Content = $"Attempt to connect to {AddressBox.Text} and launch the game."
-                });
-                ConnectButton.IsEnabled = true;
-            }
-        }
-
-        private void PasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
-        {
-            if (AddressBox.Text.Length == 0 || UsernameBox.Text.Length == 0 || PasswordBox.Password.Length == 0 || string.IsNullOrEmpty(App.ManagerConfig.InstallPath))
-            {
-                ToolTipService.SetToolTip(ConnectButton, new ToolTip()
-                {
-                    Content = $"Fill in all the fields first."
-                });
-                ConnectButton.IsEnabled = false;
-            }
-            else if (AddressBox.Text.Length > 0)
-            {
-                ToolTipService.SetToolTip(ConnectButton, new ToolTip()
-                {
-                    Content = $"Attempt to connect to {AddressBox.Text} and launch the game."
-                });
-                ConnectButton.IsEnabled = true;
-            }
+                Content = missingInfo ? "Fill in all the fields first." : $"Attempt to connect to {AddressBox.Text} and launch the game."
+            });
         }
 
         /// <summary>

--- a/SIT.Manager/Pages/PlayPage.xaml.cs
+++ b/SIT.Manager/Pages/PlayPage.xaml.cs
@@ -135,19 +135,23 @@ namespace SIT.Manager.Pages
                 return "error";
             }
 
-            if (!AddressBox.Text.Contains(@"http://"))
+            try
             {
-                AddressBox.Text = @"http://" + AddressBox.Text;
+                UriBuilder builder = new(AddressBox.Text);
+                builder.Port = builder.Port == 80 ? 6969 : builder.Port;
+                AddressBox.Text = builder.Uri.ToString().TrimEnd(new[] { '/', '\\' });
             }
+            catch(UriFormatException)
+            {
+                await new ContentDialog()
+                {
+                    XamlRoot = Content.XamlRoot,
+                    Title = "Input Error",
+                    Content = "Invalid address.",
+                    CloseButtonText = "Ok"
+                }.ShowAsync(ContentDialogPlacement.InPlace);
 
-            if (AddressBox.Text.EndsWith(@"/") || AddressBox.Text.EndsWith(@"\"))
-            {
-                AddressBox.Text = AddressBox.Text.Remove(AddressBox.Text.Length - 1, 1);
-            }
-            
-            if (!Regex.IsMatch(AddressBox.Text, @":\d{2,5}$"))
-            {
-                AddressBox.Text = AddressBox.Text + @":6969";
+                return "error";
             }
             
             string returnData = await LoginToServer();

--- a/SIT.Manager/Pages/PlayPage.xaml.cs
+++ b/SIT.Manager/Pages/PlayPage.xaml.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
+using System.Linq;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -182,6 +183,9 @@ namespace SIT.Manager.Pages
                 // If failed, attempt to register
                 if (returnData == "FAILED")
                 {
+                    string jsonData = requesting.PostJson("/launcher/server/connect", JsonSerializer.Serialize(new object())).ToString();
+                    Newtonsoft.Json.Linq.JObject connectData = Newtonsoft.Json.Linq.JObject.Parse(jsonData);
+                    AkiServer.Editions = connectData["editions"].Values<string>().ToArray();
                     ContentDialog createAccountDialog = new()
                     {
                         XamlRoot = Content.XamlRoot,


### PR DESCRIPTION
UriBuilder feels like the right choice here instead of directly manipulating the address string. UriBuilder will default to the scheme `http://` if none is supplied and will default to port 80 if none is specified which we swap to SIT default 6969 and trip the trailing `/`. The only functional difference in this change that i found was that supplying an address along the lines of `1.1.1` will be converted to `1.1.0.1`, this doesn't seem like a huge deal to me but I can add a regex check if this behavior is undesirable