### PR TITLE
show error when installed takrov version is older than required by spt

### DIFF
--- a/SIT.Manager/Classes/Utils.cs
+++ b/SIT.Manager/Classes/Utils.cs
@@ -752,5 +752,38 @@ namespace SIT.Manager.Classes
                 });
             }
         }
+
+        /// <summary>
+        /// Compares two version strings.
+        /// </summary>
+        /// <param name="version1">The first version string to compare.</param>
+        /// <param name="version2">The second version string to compare.</param>
+        /// <returns>
+        /// Returns 1 if version1 is greater than version2.
+        /// Returns -1 if version1 is less than version2.
+        /// Returns 0 if both versions are equal.
+        /// </returns>
+        /// <remarks>
+        /// This method splits the version strings by '.' and compares each part from left to right.
+        /// If a version string has more parts than the other, the extra parts are considered as 0.
+        /// </remarks>
+        public static int CompareVersions(string version1, string version2)
+        {
+            var parts1 = version1.Split('.');
+            var parts2 = version2.Split('.');
+
+            int length = Math.Max(parts1.Length, parts2.Length);
+
+            for (int i = 0; i < length; i++)
+            {
+                int v1 = i < parts1.Length ? int.Parse(parts1[i]) : 0;
+                int v2 = i < parts2.Length ? int.Parse(parts2[i]) : 0;
+
+                if (v1 > v2) return 1;
+                if (v1 < v2) return -1;
+            }
+
+            return 0;
+        }
     }
 }

--- a/SIT.Manager/Controls/SelectDowngradePatcherMirrorDialog.xaml.cs
+++ b/SIT.Manager/Controls/SelectDowngradePatcherMirrorDialog.xaml.cs
@@ -54,6 +54,18 @@ namespace SIT.Manager.Controls
             string tarkovBuild = App.ManagerConfig.TarkovVersion.Split(".").Last();
             string sitVersionTargetBuild = sitVersionTarget.Split(".").Last();
 
+            if (Utils.CompareVersions(tarkovBuild, sitVersionTargetBuild) < 0)
+            {
+                Loggy.LogToFile(string.Format("Tarkov build is version %s, while SIT requires %s.", tarkovBuild, sitVersionTargetBuild));
+                // add a message to the mirror box
+                providerLinks.Add("The installed Tarkov version is lower than the SPT required version. Please update Tarkov.", "");
+                MirrorBox.DataContext = providerLinks;
+                MirrorBox.ItemsSource = providerLinks;
+                
+                MirrorBox.SelectedIndex = 0;
+                return;
+            }
+
             GiteaRelease compatibleDowngradePatcher = null;
 
             foreach (var release in giteaReleases)


### PR DESCRIPTION
- compare the versions and error if tarkov is older than requried spt
- show the error in the mirrorbox (/selectbox). (let me know if this is not wanted, but I see it as a win for the not so tech-savvy users to not require the log for an easy error)